### PR TITLE
feat(ray): add ray & 3rd changes

### DIFF
--- a/include/geometry/ray.h
+++ b/include/geometry/ray.h
@@ -1,0 +1,16 @@
+#ifndef GEOMETRY_RAY_H
+#define GEOMETRY_RAY_H
+
+#include <geometry/point.h>
+#include <geometry/vetor.h>
+
+struct Ray {
+    Point location;
+    Vetor direction;
+
+    Ray();
+    Ray(Point location, Vetor direction);
+    Point pointAt(double t) const;
+};
+
+#endif

--- a/include/geometry/utils.h
+++ b/include/geometry/utils.h
@@ -1,6 +1,8 @@
 #ifndef GEOMETRY_UTILS_H
 #define GEOMETRY_UTILS_H
 
+#define PI 3.1415926535897932384
+
 extern const double EPSILON;
 extern int cmp(double a, double b);
 

--- a/include/geometry/vetor.h
+++ b/include/geometry/vetor.h
@@ -8,6 +8,8 @@ struct Vetor{
     Vetor();
     Vetor(double x, double y, double z);
     Vetor(Point p);
+
+    Point getPoint() const;
     double dot(const Vetor &other) const;
     Vetor cross(const Vetor &other) const;
     double angle(const Vetor &other) const;
@@ -17,8 +19,9 @@ struct Vetor{
     Vetor rotateY(double alpha) const;
     Vetor rotateZ(double alpha) const;
 
-    Vetor operator+(Vetor &other) const;
-    Vetor operator-(Vetor &other) const;
+    Vetor operator+(const Point &other) const;
+    Vetor operator+(const Vetor &other) const;
+    Vetor operator-(const Vetor &other) const;
     Vetor operator*(double p) const;
     Vetor operator/(double p) const;
     bool operator==(const Vetor &other) const;

--- a/scripts/global.mk
+++ b/scripts/global.mk
@@ -1,5 +1,5 @@
 CC := g++
-CFLAGS := -O2 -Wall -Wextra
+CFLAGS := -Wall -Werror -O2 -std=c++17
 INCLUDE := include
 LIB_CPP := $(wildcard src/**/*.cpp)
 

--- a/src/geometry/ray.cpp
+++ b/src/geometry/ray.cpp
@@ -1,0 +1,15 @@
+#include <geometry/ray.h>
+
+Ray::Ray() {
+    location = Point();
+    direction = Vetor().normalize();   
+}
+
+Ray::Ray(Point location, Vetor direction) {
+    this->location = location;
+    this->direction = direction.normalize();
+}
+
+Point Ray::pointAt(double t) const {
+    return (direction * t + location).getPoint();
+}

--- a/src/geometry/utils.cpp
+++ b/src/geometry/utils.cpp
@@ -1,5 +1,6 @@
 #include <geometry/utils.h>
 #include <cmath>
+#include <stdlib.h>
 
 const double EPSILON = 1e-12;
 

--- a/src/geometry/utils.cpp
+++ b/src/geometry/utils.cpp
@@ -1,10 +1,9 @@
 #include <geometry/utils.h>
 #include <cmath>
-#include <stdlib.h>
 
 const double EPSILON = 1e-12;
 
 int cmp(double a, double b){
-    if(abs(a - b) < EPSILON) return 0;
+    if(std::abs(a - b) < EPSILON) return 0;
     return (a < b ? -1 : 1);
 }

--- a/src/geometry/vetor.cpp
+++ b/src/geometry/vetor.cpp
@@ -8,6 +8,10 @@ Vetor::Vetor(Point p): x(p.x), y(p.y), z(p.z) {}
 
 Vetor::Vetor(double x, double y, double z): x(x), y(y), z(z) {}
 
+Point Vetor::getPoint() const {
+    return Point(x, y, z);
+}
+
 double Vetor::dot(const Vetor &other) const {
     return x*other.x + y*other.y + z*other.z;
 }
@@ -55,11 +59,15 @@ Vetor Vetor::rotateZ(double alpha) const {
     return Vetor(rx, ry, z);
 }
 
-Vetor Vetor::operator+(Vetor &other) const {
+Vetor Vetor::operator+(const Point &other) const {
     return Vetor(x + other.x, y + other.y, z + other.z);
 }
 
-Vetor Vetor::operator-(Vetor &other) const {
+Vetor Vetor::operator+(const Vetor &other) const {
+    return Vetor(x + other.x, y + other.y, z + other.z);
+}
+
+Vetor Vetor::operator-(const Vetor &other) const {
     return Vetor(x - other.x, y - other.y, z - other.z);
 }
 

--- a/tests/geometry/ray.cpp
+++ b/tests/geometry/ray.cpp
@@ -1,0 +1,16 @@
+#include <geometry/ray.h>
+#include <geometry/utils.h>
+#include <assert.h>
+
+int main() {
+    Point p(0, 0, 0);
+    Vetor v(1, 0, 0);
+
+    Ray ray(p, v);
+
+    Point at = ray.pointAt(2.0);
+
+    assert(cmp(at.x, 2.0) == 0);
+    assert(cmp(at.y, 0.0) == 0);
+    assert(cmp(at.z, 0.0) == 0);
+}

--- a/tests/geometry/vetor.cpp
+++ b/tests/geometry/vetor.cpp
@@ -1,4 +1,5 @@
 #include <geometry/vetor.h>
+#include <geometry/utils.h>
 #include <assert.h>
 #include <cmath>
 using namespace std;
@@ -13,16 +14,16 @@ int main(){
     assert(abs(v1.angle(v2) - 0.225726) < epsilon);
     assert(abs(v1.norm() - 3.741657) < epsilon);
 
-    assert(v1.normalize() == Vetor(0.267261, 0.534522, 0.801784));
-    assert(v2.normalize() == Vetor(0.455842, 0.569802, 0.683763));
+    assert(v1.normalize() == Vetor(0.267261241912424397, 0.534522483824848793, 0.80178372573727319));
+    assert(v2.normalize() == Vetor(0.455842305838551787, 0.569802882298189761, 0.683763458757827625));
 
-    assert(v1.rotateX(M_PI/2) == Vetor(1, -3, 2));
-    assert(v1.rotateY(M_PI/2) == Vetor(3, 2, -1));
-    assert(v1.rotateZ(M_PI/2) == Vetor(-2, 1, 3));
+    assert(v1.rotateX(PI/2.0) == Vetor(1, -3, 2));
+    assert(v1.rotateY(PI/2.0) == Vetor(3, 2, -1));
+    assert(v1.rotateZ(PI/2.0) == Vetor(-2, 1, 3));
     
-    assert(v2.rotateX(M_PI/2) == Vetor(4, -6, 5));
-    assert(v2.rotateY(M_PI/2) == Vetor(6, 5, -4));
-    assert(v2.rotateZ(M_PI/2) == Vetor(-5, 4, 6));
+    assert(v2.rotateX(PI/2) == Vetor(4, -6, 5));
+    assert(v2.rotateY(PI/2) == Vetor(6, 5, -4));
+    assert(v2.rotateZ(PI/2) == Vetor(-5, 4, 6));
 
     assert(v1 + v2 == Vetor(5, 7, 9));
     assert(v1 - v2 == Vetor(-3, -3, -3));


### PR DESCRIPTION
---
title: FEAT
labels: enhancement

---

## Related issues
<!-- type here the related issues -->
* Point #20 

## What I did
<!-- describe the PR -->
> Create Ray Structure & fix windows failed tests

<!-- List properties added (if applicable) -->
### Properties
- Location
- Direction

<!-- List methods added (if applicable) -->
## Methods
- `pointAt`: get the point at `t` moment

## Additional notes
* Some tests failed when runned on windows, the reason was precision (see screenshot below). To fix that, more decimals numbers added.
* Put `const` keyword on some methods.
* Define `PI` in utils, because `M_PI` on windows is break. See this [stack overflow issue](https://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio)
* changing `<math.h>` for `<cmath>`
* add `std::abs` instead of `abs`
* `c++17` flag specified.
* `getPoint` method added on `Vetor`.
* `operator+` added on `Vetor` to update values when a `Point` is passed.

![image](https://github.com/kinhosz/Appel/assets/39632709/fd157302-ee88-48e1-99b0-7c8020bbf89d)
 

<!-- ping the repo onwers -->
@kinhosz
@mateuseap
