### PR TITLE
[FIX] scene: render parallel triangles

### DIFF
--- a/example/view/parallel.cpp
+++ b/example/view/parallel.cpp
@@ -1,0 +1,97 @@
+#include <vector>
+#include <geometry/point.h>
+#include <geometry/triangle.h>
+#include <entity/triangularMesh.h>
+#include <entity/scene.h>
+#include <graphic/camera.h>
+#include <SFML/Graphics.hpp>
+#include <math.h>
+using namespace std;
+
+#define WIDTH 640
+#define HEIGHT 360
+#define FPS 30
+
+TriangularMesh buildTriangles() {
+    vector<Triangle> ts;
+    // ground
+    ts.push_back(Triangle(Point(0, 100, 0), Point(100, 0, 0), Point(-100, 0, 0), Color(0.5, 0.39, 0.83)));
+    // front
+    ts.push_back(Triangle(Point(-100, 0, 0), Point(100, 0, 0), Point(0, 0, 100), Color(0.78, 0.65, 0.98)));
+    // left
+    ts.push_back(Triangle(Point(-100, 0, 0), Point(-100, 100, 0), Point(-100, 50, 100), Color(0.87, 0.24, 0.48)));
+    // right
+    ts.push_back(Triangle(Point(100, 0, 0), Point(100, 100, 0), Point(100, 50, 100), Color(0.48, 0.24, 0.87)));
+
+    return TriangularMesh(
+        ts,
+        0.8, // kd
+        0.9, // ks
+        0.1, // ka
+        0.0, // kr
+        0.0, // kt
+        100 // roughness
+    );
+}
+
+int main() {
+    TriangularMesh mesh = buildTriangles();
+
+    Scene scene(1);
+    scene.addObject(mesh);
+
+    double y = 1000;
+    Camera camera(Point(0, 1000, 20), Point(0, 0, 20), HEIGHT, WIDTH);
+
+    Frame frame = camera.take(scene, false);
+
+    sf::RenderWindow window(sf::VideoMode(WIDTH, HEIGHT), "video");
+
+    clock_t t2;
+
+    while (window.isOpen()) {
+        t2 = clock();
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed)
+                window.close();
+        }
+
+        window.clear();
+        /************************************************/
+        sf::Image image;
+        image.create(WIDTH, HEIGHT, sf::Color::White);
+
+        for (int x = 0; x < frame.horizontal(); ++x) {
+            for (int y = 0; y < frame.vertical(); ++y) {
+                sf::Color color(
+                    frame.getPixel(x, y).getRed(),
+                    frame.getPixel(x, y).getGreen(),
+                    frame.getPixel(x, y).getBlue()
+                );
+                image.setPixel(x, y, color);
+            }
+        }
+
+        sf::Texture texture;
+        texture.loadFromImage(image);
+
+        sf::Sprite sprite(texture);
+
+        window.draw(sprite);
+        /************************************************/
+
+        y -= (y * 0.01);
+        camera.setPosition(Point(0, y, 20));
+        frame = camera.take(scene, false);
+
+        window.display();
+
+        double rs = (clock() - t2) * 1000.0 / CLOCKS_PER_SEC;
+        while(rs < (1000.0 / FPS)) {
+            rs = (clock() - t2) * 1000.0 / CLOCKS_PER_SEC;
+        }
+    }
+
+    return 0;
+}

--- a/src/entity/scene.cpp
+++ b/src/entity/scene.cpp
@@ -234,16 +234,22 @@ void Scene::sortTriangleIndexes() {
         const Triangle& triangle = mappedTriangles[i];
         double minSlope = 0.0, maxSlope = 0.0;
         bool hasSlope = false;
-        for(int i=0;i<3;i++) {
-            if(cmp(triangle.vertices[i].y, 0.0) <= 0) continue;
 
-            double slope = triangle.vertices[i].z / triangle.vertices[i].y;
+        for(int j=0;j<3;j++) {
+            if(cmp(triangle.vertices[j].y, 0.0) <= 0) continue;
+
+            double slope = triangle.vertices[j].z / triangle.vertices[j].y;
+
             if(!hasSlope) minSlope = slope, maxSlope = slope;
             minSlope = std::min(minSlope, slope);
             maxSlope = std::max(maxSlope, slope);
             hasSlope = true;
         }
         if(hasSlope) {
+            if(cmp(minSlope, maxSlope) == 0) {
+                if(cmp(minSlope, 0.0) == -1) minSlope = -1;
+                else if(cmp(minSlope, 0.0) == 1) maxSlope = 1;
+            }
             sortedTrianglesIndexes.push_back({{minSlope, maxSlope}, i});
         }
     }
@@ -253,17 +259,29 @@ void Scene::sortTriangleIndexes() {
 void Scene::activateTriangles(int& pointerToSortedIndexes, double planeSlopeVertical) {
     while(pointerToSortedIndexes < (int)sortedTrianglesIndexes.size()) {
         if(cmp(sortedTrianglesIndexes[pointerToSortedIndexes].first.first, planeSlopeVertical) == 1) break;
-        double minSlopeH, maxSlopeH;
+        double minSlopeH = 0.0, maxSlopeH = 0.0;
         int idx = sortedTrianglesIndexes[pointerToSortedIndexes].second;
         double maxSlopeV = sortedTrianglesIndexes[pointerToSortedIndexes].first.second;
+        bool hasSlope = false;
 
         for(int i=0;i<3;i++){
             double slope = mappedTriangles[idx].vertices[i].x / mappedTriangles[idx].vertices[i].y;
-            if(i == 0) minSlopeH = slope, maxSlopeH = slope;
+
+            if(!hasSlope) {
+                minSlopeH = slope;
+                maxSlopeH = slope;
+                hasSlope = true;
+            }
             minSlopeH = std::min(minSlopeH, slope);
             maxSlopeH = std::max(maxSlopeH, slope);
         }
-        activeIndexes.push_back({{minSlopeH, maxSlopeH}, {maxSlopeV, idx}});
+        if(hasSlope) {
+            if(cmp(minSlopeH, maxSlopeH) == 0) {
+                if(cmp(minSlopeH, 0.0) == -1) minSlopeH = -1;
+                else if(cmp(minSlopeH, 0.0) == 1) maxSlopeH = 1;
+            }
+            activeIndexes.push_back({{minSlopeH, maxSlopeH}, {maxSlopeV, idx}});
+        }
         pointerToSortedIndexes++;
     }
     std::sort(activeIndexes.begin(), activeIndexes.end());


### PR DESCRIPTION
Os triângulos paralelos ao sistema de coordenadas do observador, em especial, os triângulos que estavam totalmente contido no plano XY (basicamente o chão). Estavam sumindo quando um de seus pontos estava atrás do observador. Este PR fixa isso.

https://github.com/user-attachments/assets/0747a76a-2596-42f6-9a4c-eaebe98c0bb4

